### PR TITLE
feat: Diff file tree + collapsible sidebar

### DIFF
--- a/frontend/src/components/DiffCard.tsx
+++ b/frontend/src/components/DiffCard.tsx
@@ -208,8 +208,8 @@ export default function DiffCard({
   const expandable = true;
 
   return (
-    <div className="my-4 border">
-      <div className="flex items-center px-4 py-2">
+    <div className="my-4 border rounded overflow-hidden">
+      <div className="flex items-center px-4 py-2 bg-background border-b">
         {expandable && (
           <Button
             variant="ghost"

--- a/frontend/src/components/diff/DiffFileTree.tsx
+++ b/frontend/src/components/diff/DiffFileTree.tsx
@@ -1,0 +1,149 @@
+import { useMemo, useState, useCallback } from 'react';
+import type { Diff } from 'shared/types';
+import { buildDiffTree, toFileStats, type DiffTreeNode } from '@/utils/diffTree';
+import {
+  ChevronRight,
+  ChevronDown,
+  Folder,
+  FolderOpen,
+  File as FileIcon,
+  FilePlus2,
+  Trash2,
+  ArrowLeftRight,
+  Copy,
+  Key,
+  PencilLine,
+} from 'lucide-react';
+
+type Props = {
+  diffs: Diff[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  className?: string;
+};
+
+function ChangeIcon({ kind }: { kind: Diff['change'] }) {
+  if (kind === 'deleted') return <Trash2 className="h-3.5 w-3.5 text-red-500" />;
+  if (kind === 'renamed') return <ArrowLeftRight className="h-3.5 w-3.5" />;
+  if (kind === 'added') return <FilePlus2 className="h-3.5 w-3.5 text-green-600" />;
+  if (kind === 'copied') return <Copy className="h-3.5 w-3.5" />;
+  if (kind === 'permissionChange') return <Key className="h-3.5 w-3.5" />;
+  return <PencilLine className="h-3.5 w-3.5" />; // modified
+}
+
+function Counts({ add, del }: { add: number; del: number }) {
+  return (
+    <span className="ml-auto pl-2 text-[11px] tabular-nums">
+      <span style={{ color: 'hsl(var(--console-success))' }}>+{add}</span>
+      <span className="ml-1" style={{ color: 'hsl(var(--console-error))' }}>
+        -{del}
+      </span>
+    </span>
+  );
+}
+
+export function DiffFileTree({ diffs, activeId, onSelect, className }: Props) {
+  const stats = useMemo(() => toFileStats(diffs), [diffs]);
+  const tree = useMemo(() => buildDiffTree(stats), [stats]);
+  const fileCount = stats.length;
+
+  // Expanded state keyed by directory path
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const s = new Set<string>();
+    // Expand all top-level directories by default
+    tree.forEach((n) => {
+      if (n.type === 'dir') s.add(n.path);
+    });
+    return s;
+  });
+
+  const toggleDir = useCallback((path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(path) ? next.delete(path) : next.add(path);
+      return next;
+    });
+  }, []);
+
+  const renderNode = (node: DiffTreeNode, depth = 0) => {
+    const padding = 8 + depth * 12;
+    if (node.type === 'dir') {
+      const isOpen = expanded.has(node.path);
+      return (
+        <div key={node.path} className="min-w-0">
+          <button
+            type="button"
+            aria-expanded={isOpen}
+            onClick={() => toggleDir(node.path)}
+            className="w-full flex items-center justify-start gap-1.5 px-2 py-1 rounded hover:bg-muted/60 overflow-hidden"
+            style={{ paddingLeft: padding }}
+          >
+            {isOpen ? (
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            )}
+            {isOpen ? (
+              <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : (
+              <Folder className="h-3.5 w-3.5 text-muted-foreground" />
+            )}
+            <span className="text-sm font-medium text-foreground/90 flex-1 min-w-0 truncate text-left">
+              {node.name}
+            </span>
+            <Counts add={node.add} del={node.del} />
+          </button>
+          {isOpen && node.children.map((c) => renderNode(c, depth + 1))}
+        </div>
+      );
+    }
+
+    const isActive = activeId === node.id;
+    return (
+      <button
+        key={node.id}
+        type="button"
+        onClick={() => onSelect(node.id)}
+        className={`w-full flex items-center justify-start gap-2 px-2 py-1 rounded hover:bg-muted/60 overflow-hidden ${
+          isActive ? 'bg-muted' : ''
+        }`}
+        style={{ paddingLeft: padding + 14 }}
+        aria-current={isActive ? 'true' : undefined}
+      >
+        {/* Using change icon if available, else generic file */}
+        {node.change ? (
+          <ChangeIcon kind={node.change} />
+        ) : (
+          <FileIcon className="h-3.5 w-3.5" />
+        )}
+        <span
+          className="text-sm font-mono truncate flex-1 min-w-0 text-foreground text-left"
+          title={node.path}
+        >
+          {node.name}
+        </span>
+        <Counts add={node.add} del={node.del} />
+      </button>
+    );
+  };
+
+  return (
+    <aside
+      className={`border-r shrink-0 w-[18rem] min-w-[14rem] h-full min-h-0 overflow-y-auto flex flex-col bg-background ${className || ''}`}
+    >
+      <div className="sticky top-0 z-10 bg-background border-b">
+        <div className="px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
+          <span className="font-medium text-foreground">
+            {fileCount === 1 ? 'File Changed' : 'Files Changed'}
+          </span>
+          <span className="text-muted-foreground tabular-nums">({fileCount})</span>
+        </div>
+      </div>
+      <div className="py-1 flex-1 min-h-0">
+        {tree.map((n) => renderNode(n))}
+      </div>
+    </aside>
+  );
+}
+
+export default DiffFileTree;

--- a/frontend/src/components/tasks/TaskDetailsHeader.tsx
+++ b/frontend/src/components/tasks/TaskDetailsHeader.tsx
@@ -1,5 +1,13 @@
 import { memo } from 'react';
-import { Edit, Trash2, X, Maximize2, Minimize2 } from 'lucide-react';
+import {
+  Edit,
+  Trash2,
+  X,
+  Maximize2,
+  Minimize2,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Tooltip,
@@ -20,6 +28,9 @@ interface TaskDetailsHeaderProps {
   hideCloseButton?: boolean;
   isFullScreen?: boolean;
   setFullScreen?: (isFullScreen: boolean) => void;
+  // Optional: fullscreen header left-side toggle for collapsing the sidebar
+  onToggleSidebar?: () => void;
+  isSidebarCollapsed?: boolean;
 }
 
 // backgroundColor: `hsl(var(${statusBoardColors[task.status]}) / 0.03)`,
@@ -32,6 +43,8 @@ function TaskDetailsHeader({
   hideCloseButton = false,
   isFullScreen,
   setFullScreen,
+  onToggleSidebar,
+  isSidebarCollapsed,
 }: TaskDetailsHeaderProps) {
   return (
     <div>
@@ -39,7 +52,34 @@ function TaskDetailsHeader({
         className="flex shrink-0 items-center gap-2 border-b border-dashed bg-background"
         style={{}}
       >
-        <div className="p-3 flex flex-1 items-center truncate">
+        <div className="p-3 flex flex-1 items-center truncate gap-2">
+          {/* Sidebar toggle (fullscreen only) */}
+          {isFullScreen && onToggleSidebar && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="h-6 w-6 p-0"
+                    onClick={onToggleSidebar}
+                    aria-label={
+                      isSidebarCollapsed ? 'Show details' : 'Hide details'
+                    }
+                  >
+                    {isSidebarCollapsed ? (
+                      <PanelLeftOpen className="h-4 w-4" />
+                    ) : (
+                      <PanelLeftClose className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{isSidebarCollapsed ? 'Show details' : 'Hide details'}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
           <div
             className="h-2 w-2 rounded-full inline-block"
             style={{

--- a/frontend/src/components/tasks/TaskDetailsPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailsPanel.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+// import { Button } from '@/components/ui/button';
+// no icon imports needed here (header contains the toggle)
 import TaskDetailsHeader from './TaskDetailsHeader';
 import { TaskFollowUpSection } from './TaskFollowUpSection';
 import { TaskTitleDescription } from './TaskDetails/TaskTitleDescription';
@@ -108,6 +110,9 @@ export function TaskDetailsPanel({
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [onClose, isDialogOpen]);
 
+  // Fullscreen sidebar collapse state
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
   return (
     <>
       {!task ? null : (
@@ -138,19 +143,22 @@ export function TaskDetailsPanel({
                       hideCloseButton={hideBackdrop}
                       isFullScreen={isFullScreen}
                       setFullScreen={setFullScreen}
+                      onToggleSidebar={() => setSidebarCollapsed((v) => !v)}
+                      isSidebarCollapsed={sidebarCollapsed}
                     />
                   )}
 
                   {isFullScreen ? (
                     <div className="flex-1 min-h-0 flex">
-                      {/* Sidebar */}
-                      <aside
-                        className={`w-[28rem] shrink-0 border-r overflow-y-auto ${inIframe() ? 'hidden' : ''}`}
-                      >
-                        {/* Fullscreen sidebar shows title and description above edit/delete */}
-                        <div className="space-y-2 p-3">
-                          <TaskTitleDescription task={task} />
-                        </div>
+                      {/* Sidebar (hidden when collapsed) */}
+                      {!sidebarCollapsed && (
+                        <aside
+                          className={`w-[28rem] shrink-0 border-r overflow-y-auto ${inIframe() ? 'hidden' : ''}`}
+                        >
+                          {/* Title section */}
+                          <div className="p-3 border-b">
+                            <TaskTitleDescription task={task} />
+                          </div>
 
                         {/* Current Attempt / Actions */}
                         <TaskDetailsToolbar
@@ -169,11 +177,12 @@ export function TaskDetailsPanel({
                         <TodoPanel selectedAttempt={selectedAttempt} />
 
                         {/* Task Relationships */}
-                        <TaskRelationshipViewer
-                          selectedAttempt={selectedAttempt}
-                          onNavigateToTask={onNavigateToTask}
-                        />
-                      </aside>
+                            <TaskRelationshipViewer
+                              selectedAttempt={selectedAttempt}
+                              onNavigateToTask={onNavigateToTask}
+                            />
+                          </aside>
+                      )}
 
                       {/* Main content */}
                       <main className="flex-1 min-h-0 min-w-0 flex flex-col">

--- a/frontend/src/components/tasks/TaskDetailsToolbar.tsx
+++ b/frontend/src/components/tasks/TaskDetailsToolbar.tsx
@@ -15,7 +15,6 @@ import { useTaskStopping } from '@/stores/useTaskDetailsUiStore';
 import CreateAttempt from '@/components/tasks/Toolbar/CreateAttempt.tsx';
 import CurrentAttempt from '@/components/tasks/Toolbar/CurrentAttempt.tsx';
 import { useUserSystem } from '@/components/config-provider';
-import { Card } from '../ui/card';
 
 // UI State Management
 type UiAction =
@@ -243,9 +242,6 @@ function TaskDetailsToolbar({
           />
         ) : (
           <div className="">
-            <Card className="bg-background border-y border-dashed p-3 text-sm">
-              Actions
-            </Card>
             <div className="p-3">
               {/* Current Attempt Info */}
               <div className="space-y-2">

--- a/frontend/src/hooks/useActiveAnchor.ts
+++ b/frontend/src/hooks/useActiveAnchor.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Observe a list of anchor elements inside a scroll container and
+ * return the id of the anchor that is closest to the top (in view).
+ */
+export function useActiveAnchor(
+  container: React.RefObject<HTMLElement>,
+  anchorIds: string[]
+) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const rootEl = container.current;
+    if (!rootEl || anchorIds.length === 0) return;
+
+    const anchors = anchorIds
+      .map((id) => document.getElementById(`diff-${id}`))
+      .filter(Boolean) as HTMLElement[];
+    if (anchors.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Find entry with the smallest root boundingClientRect top distance (visible)
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) {
+          const id = visible[0].target.getAttribute('data-anchor-id');
+          if (id) setActiveId(id);
+          return;
+        }
+
+        // Fallback: if none visible, pick the one just above viewport
+        const above = anchors
+          .map((el) => ({
+            el,
+            top: el.getBoundingClientRect().top - rootEl.getBoundingClientRect().top,
+          }))
+          .filter((x) => x.top <= 8) // small threshold
+          .sort((a, b) => b.top - a.top);
+        if (above[0]) {
+          const id = above[0].el.getAttribute('data-anchor-id');
+          if (id) setActiveId(id);
+        }
+      },
+      { root: rootEl, threshold: [0, 1.0] }
+    );
+
+    anchors.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [container, anchorIds.join('|')]);
+
+  return activeId;
+}
+

--- a/frontend/src/lib/responsive-config.ts
+++ b/frontend/src/lib/responsive-config.ts
@@ -44,7 +44,8 @@ export const getTaskPanelClasses = (forceFullScreen: boolean) => {
 };
 
 export const getTaskPanelInnerClasses = () => {
-  return `flex-1 flex flex-col min-h-0 w-full max-w-[1400px] bg-muted border-x`;
+  // Remove the 1400px max width to allow full-width detail view
+  return `flex-1 flex flex-col min-h-0 w-full max-w-none bg-muted border-x`;
 };
 
 // Generate classes for backdrop (only show in overlay mode)

--- a/frontend/src/utils/diffTree.ts
+++ b/frontend/src/utils/diffTree.ts
@@ -1,0 +1,152 @@
+import type { Diff, DiffChangeKind } from 'shared/types';
+import { generateDiffFile } from '@git-diff-view/file';
+
+export type FileStat = {
+  id: string; // key used in DiffTab
+  path: string; // newPath || oldPath || id
+  change: DiffChangeKind;
+  add: number;
+  del: number;
+};
+
+export type DiffTreeNode =
+  | {
+      type: 'dir';
+      name: string;
+      path: string; // full path for directory
+      children: DiffTreeNode[];
+      add: number; // aggregated
+      del: number; // aggregated
+    }
+  | {
+      type: 'file';
+      name: string;
+      path: string; // full path for file
+      id: string; // anchor id
+      change: DiffChangeKind;
+      add: number;
+      del: number;
+    };
+
+function computeAddDelForDiff(diff: Diff): { add: number; del: number } {
+  try {
+    const oldName = diff.oldPath || diff.newPath || 'unknown';
+    const newName = diff.newPath || diff.oldPath || 'unknown';
+    const oldContent = diff.oldContent || '';
+    const newContent = diff.newContent || '';
+    const oldLang = '';
+    const newLang = '';
+    const file = generateDiffFile(
+      oldName,
+      oldContent,
+      newName,
+      newContent,
+      oldLang,
+      newLang
+    );
+    file.initRaw();
+    return {
+      add: file.additionLength ?? 0,
+      del: file.deletionLength ?? 0,
+    };
+  } catch {
+    return { add: 0, del: 0 };
+  }
+}
+
+export function toFileStats(diffs: Diff[]): FileStat[] {
+  return diffs.map((d, i) => {
+    const id = d.newPath || d.oldPath || String(i);
+    const path = (d.newPath || d.oldPath || String(i)).replace(/^\/+/, '');
+    const { add, del } = computeAddDelForDiff(d);
+    return { id, path, change: d.change, add, del };
+  });
+}
+
+export function buildDiffTree(stats: FileStat[]): DiffTreeNode[] {
+  const root: Record<string, DiffTreeNode> = {};
+
+  for (const s of stats) {
+    const parts = s.path.split('/').filter(Boolean);
+    let cursor = root;
+    let currentPath = '';
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      const isLeaf = i === parts.length - 1;
+
+      if (isLeaf) {
+        cursor[part] = {
+          type: 'file',
+          name: part,
+          path: currentPath,
+          id: s.id,
+          change: s.change,
+          add: s.add,
+          del: s.del,
+        } as DiffTreeNode;
+      } else {
+        if (!cursor[part]) {
+          cursor[part] = {
+            type: 'dir',
+            name: part,
+            path: currentPath,
+            children: [],
+            add: 0,
+            del: 0,
+          } as DiffTreeNode;
+        }
+        // move cursor to children map
+        const node = cursor[part] as DiffTreeNode;
+        if (node.type !== 'dir') {
+          // convert existing file node into dir (should not happen normally)
+          cursor[part] = {
+            type: 'dir',
+            name: part,
+            path: currentPath,
+            children: [],
+            add: node.add || 0,
+            del: node.del || 0,
+          } as DiffTreeNode;
+        }
+        // @ts-ignore - we want an object-style map at this level
+        if (!cursor[part]._childMap) cursor[part]._childMap = {};
+        // @ts-ignore
+        cursor = cursor[part]._childMap;
+      }
+    }
+  }
+
+  // Convert to arrays and aggregate counts
+  function toArray(map: Record<string, DiffTreeNode>): DiffTreeNode[] {
+    const arr: DiffTreeNode[] = [];
+    for (const key of Object.keys(map)) {
+      const node = map[key];
+      // @ts-ignore
+      const childMap = node._childMap as Record<string, DiffTreeNode> | undefined;
+      if (node.type === 'dir') {
+        const children = childMap ? toArray(childMap) : [];
+        let add = 0;
+        let del = 0;
+        for (const c of children) {
+          add += c.add;
+          del += c.del;
+        }
+        arr.push({ ...node, children, add, del });
+      } else {
+        arr.push(node);
+      }
+    }
+
+    // Sort: directories first, then files; alphabetical by name
+    arr.sort((a, b) => {
+      if (a.type !== b.type) return a.type === 'dir' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    return arr;
+  }
+
+  return toArray(root);
+}
+


### PR DESCRIPTION
## Overview
Adds a file tree to the Diffs tab and a collapsible left sidebar in full‑screen to improve navigation and conserve screen space during review.

<img width="1707" height="983" alt="スクリーンショット 2025-09-14 10 11 15" src="https://github.com/user-attachments/assets/3788e61d-d641-4e9d-9c8d-d6f3ea4c91a2" />

## What I Did
- Added a file tree with a “Files Changed (N)”.
- Added a header toggle to open/close the left sidebar in full‑screen.
- Updated the DiffCard header styling (bg‑background with a bottom border).
- Removed global width constraints.

## Verification
- Type checks pass: npm run frontend:check.
- Manually verified in dev: navigating via the tree opens the corresponding diff, the sidebar toggle works in full‑screen, and there are no console errors.
